### PR TITLE
PersistentState service + full integration with ViewEditor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/.DS_Store
 builds/*
 
-state.json
+.pathbench.json
 
 # custom additions #
 training_data/

--- a/src/algorithms/classic/graph_based/a_star.py
+++ b/src/algorithms/classic/graph_based/a_star.py
@@ -21,10 +21,6 @@ Heap duplicates https://www.redblobgames.com/pathfinding/a-star/implementation.h
 
 
 class AStar(Algorithm):
-    PQ_COLOUR_HIGH: Colour = BLUE
-    PQ_COLOUR_LOW: Colour = Colour(0.27, 0.33, 0.35, 0.2)
-    VISITED_COLOUR: Colour = Colour(0.19, 0.19, 0.2, 0.8)
-
     class InternalMemory:
         priority_queue: List[Tuple[int, Point]]
         visited: Set[Point]
@@ -41,19 +37,27 @@ class AStar(Algorithm):
 
     mem: InternalMemory
 
+    pq_colour_max: DynamicColour
+    pq_colour_min: DynamicColour
+    visited_colour: DynamicColour
+
     def __init__(self, services: Services, testing: BasicTesting = None):
         super().__init__(services, testing)
 
         self.mem = AStar.InternalMemory()
+
+        self.pq_colour_max = self._services.state.add_colour("explored max", BLUE)
+        self.pq_colour_min = self._services.state.add_colour("explored min", Colour(0.27, 0.33, 0.35, 0.2))
+        self.visited_colour = self._services.state.add_colour("visited", Colour(0.19, 0.19, 0.2, 0.8))
 
     def set_display_info(self) -> List[MapDisplay]:
         """
         Read super description
         """
         return super().set_display_info() + [
-            SolidColorMapDisplay(self._services, self.mem.visited, DynamicColour(self.VISITED_COLOUR), z_index=50),
+            SolidColorMapDisplay(self._services, self.mem.visited, self.visited_colour, z_index=50),
             GradientMapDisplay(self._services, pts=self.mem.priority_queue,
-                               min_color=DynamicColour(self.PQ_COLOUR_LOW), max_color=DynamicColour(self.PQ_COLOUR_HIGH), z_index=49, inverted=True),
+                               min_color=self.pq_colour_min, max_color=self.pq_colour_max, z_index=49, inverted=True),
         ]
 
     # noinspection PyUnusedLocal

--- a/src/simulator/models/map.py
+++ b/src/simulator/models/map.py
@@ -1,4 +1,3 @@
-import pygame
 from threading import Thread, Condition
 
 from algorithms.configuration.maps.sparse_map import SparseMap

--- a/src/simulator/models/model.py
+++ b/src/simulator/models/model.py
@@ -5,7 +5,7 @@ from simulator.services.services import Services
 class Model:
     """
     The model base class
-    All controllers should inherit from this class
+    All logic should inherit from this class
     """
 
     _services: Services

--- a/src/simulator/models/persistent_state.py
+++ b/src/simulator/models/persistent_state.py
@@ -1,0 +1,130 @@
+
+from structures import DynamicColour, Colour, TRANSPARENT
+from simulator.services.services import Services
+from simulator.models.model import Model
+
+from typing import Optional, Callable, Dict
+from functools import partial
+import json
+
+class View():
+    __services: Services
+    state: 'PersistentState'
+    index: int
+
+    colours: Dict[str, DynamicColour]
+
+    def __init__(self, services: Services, state: 'PersistentState', index: int) -> None:
+        self.__services = services
+        self.state = state
+        self.index = index
+
+        self.colours = {}
+    
+    def __colour_callback(self, colour: DynamicColour) -> None:
+        if self.index == self.state.view_idx:
+            self.state.colours[colour.name].set_all(colour.colour, colour.visible)
+        self.__services.ev_manager.post(ColourUpdateEvent(colour, view=self))
+
+    def _add_colour(self, name: str, colour: Colour, visible: bool) -> DynamicColour:
+        dc = self.colours[name] = DynamicColour(colour, name, self._colour_callback, visible)
+        return dc
+
+    def _from_json(self, data: Dict[str, Any]) -> None:
+        for n, c in data["colours"].items():
+            colour = Colour(*c["colour"])
+            visible = bool(c["visible"])
+            self.colours[n] = DynamicColour(colour, n, self.__colour_callback, visible)
+
+    def _to_json(self) -> Dict[str, Any]:
+        data = {}
+        dc = data["colours"] = {}
+        for n, c in self.colours.items():
+            dc[n] = {}
+            dc[n]["colour"] = tuple(*c.colour)
+            dc[n]["visible"] = tuple(*c.visible)
+        return data
+
+class PersistentState(Model):
+    __services: Services
+
+    colours: Dict[str, DynamicColour]
+    views: List[View]
+    __view_idx: int
+    
+    MAX_VIEWS: int = 6
+
+    FILE_NAME: str = ".pathbench.json"
+    
+    def __init__(self, services: Services):
+        self.__services = services
+
+        self.colours = {}
+        self.views = [View(services, self, i) for i in range(self.MAX_VIEWS)]
+        self.__view_idx = 0
+
+        self.__load()
+
+    def __load(self) -> None:
+        def check(req: bool) -> None:
+            if not req:
+                raise RuntimeError("{} is corrupted".format(self.FILE_NAME))
+
+        if os.path.isfile(self.FILE_NAME):
+            with open(self.FILE_NAME, 'r') as f:
+                data = json.load(f)
+                
+                try:
+                    check(isinstance(data, list))
+                    check(len(data) == self.MAX_VIEWS)
+                    for v in range(len(data)):
+                        check(isinstance(v, dict))
+                        self.views[v]._from_json(data[v])
+                except RuntimeError as e:
+                    print(e)
+    
+    def __save(self) -> None:
+        pass
+
+    def __colour_callback(self, colour: DynamicColour) -> None:
+        self.__services.ev_manager.post(ColourUpdateEvent(colour))
+
+    def add_colour(self, name: str, default_colour: Colour, default_visible: bool = True) -> DynamicColour:
+        if name in self.colours:
+            return self.colours[name]
+        
+        dc = self.colours[name] = DynamicColour(default_colour, name, self.__colour_callback, default_visible)
+        for v in range(len(self.views)):
+            self.views[v]._add_colour(name, default_colour, default_visible)
+        callback(dc)
+        return dc
+
+    @property
+    def view_idx(self) -> str:
+        return 'view_idx'
+    
+    @view_idx.getter
+    def view_idx(self) -> int:
+        return self.__view_idx
+    
+    @view_idx.setter
+    def view_idx(self, idx: int) -> None:
+        self.__view_idx = idx
+        for n, c in self.views[idx].colours.items():
+            self.colours[n].set_all(c.colour, c.visible)
+
+    @property
+    def view(self) -> str:
+        return 'view'
+
+    @view.getter
+    def view(self) -> View:
+        return self.views[self.view_idx]
+    
+    @view.setter
+    def view(self, v: View) -> None:
+        assert v == self.views[v.index], "View is not owned by this PersistentState"
+
+        self.__view_idx = v.index
+        for n, c in v.colours.items():
+            self.colours[n].set_all(c.colour, c.visible)

--- a/src/simulator/models/persistent_state.py
+++ b/src/simulator/models/persistent_state.py
@@ -3,7 +3,7 @@ from structures import DynamicColour, Colour, TRANSPARENT
 from simulator.services.services import Services
 from simulator.models.model import Model
 
-from typing import Optional, Callable, Dict
+from typing import Optional, Callable, Dict, Final
 from functools import partial
 import json
 
@@ -11,8 +11,9 @@ class View():
     __services: Services
     state: 'PersistentState'
     index: int
-
     colours: Dict[str, DynamicColour]
+
+    EFFECTIVE_VIEW: Final[int] = -1
 
     def __init__(self, services: Services, state: 'PersistentState', index: int) -> None:
         self.__services = services
@@ -24,11 +25,19 @@ class View():
     def __colour_callback(self, colour: DynamicColour) -> None:
         if self.index == self.state.view_idx:
             self.state.colours[colour.name].set_all(colour.colour, colour.visible)
-        self.__services.ev_manager.post(ColourUpdateEvent(colour, view=self))
+        self.__services.ev_manager.post(ColourUpdateEvent(colour, self))
 
-    def _add_colour(self, name: str, colour: Colour, visible: bool) -> DynamicColour:
-        dc = self.colours[name] = DynamicColour(colour, name, self._colour_callback, visible)
+    def _add_colour(self, name: str, colour: Colour, visible: bool, invoke_callback: bool = True) -> DynamicColour:
+        if name in self.colours:
+            return self.colours[name]
+        dc = self.colours[name] = DynamicColour(colour, name, self.__colour_callback, visible)
+        if invoke_callback:
+            self.__colour_callback(dc)
         return dc
+
+    def _from_view(self, other: View) -> None:
+        for n, c in other.colours.items():
+            self.colours[n].set_all(c.colour, c.visible)
 
     def _from_json(self, data: Dict[str, Any]) -> None:
         for n, c in data["colours"].items():
@@ -45,58 +54,82 @@ class View():
             dc[n]["visible"] = tuple(*c.visible)
         return data
 
+    @property
+    def is_effective(self) -> bool:
+        return self.index == View.EFFECTIVE_VIEW
+
 class PersistentState(Model):
     __services: Services
+    file_name: str
 
-    colours: Dict[str, DynamicColour]
+    MAX_VIEWS: Final[int] = 6
+    effective_view: View
     views: List[View]
     __view_idx: int
     
-    MAX_VIEWS: int = 6
-
-    FILE_NAME: str = ".pathbench.json"
-    
-    def __init__(self, services: Services):
+    def __init__(self, services: Services, file_name: str = ".pathbench.json"):
         self.__services = services
+        self.file_name = file_name
 
-        self.colours = {}
+        self.__reset()
+        self.__load()
+        self.__save()
+    
+    def __reset(self):
+        self.effective_view = View(services, self, View.EFFECTIVE_VIEW)
         self.views = [View(services, self, i) for i in range(self.MAX_VIEWS)]
         self.__view_idx = 0
-
-        self.__load()
 
     def __load(self) -> None:
         def check(req: bool) -> None:
             if not req:
-                raise RuntimeError("{} is corrupted".format(self.FILE_NAME))
+                raise RuntimeError
 
-        if os.path.isfile(self.FILE_NAME):
-            with open(self.FILE_NAME, 'r') as f:
-                data = json.load(f)
+        if os.path.isfile(self.file_name):
+            with open(self.file_name, 'r') as f:
+                jdata = json.load(f)
                 
                 try:
-                    check(isinstance(data, list))
-                    check(len(data) == self.MAX_VIEWS)
-                    for v in range(len(data)):
+                    check(isinstance(jdata, dict))
+                    jidx = jdata["view_index"]
+                    check(jidx >= 0 and jidx < self.MAX_VIEWS)
+                    jviews = jdata["views"]
+                    check(isinstance(jviews, list))
+                    check(len(jviews) == self.MAX_VIEWS)
+                    for v in range(len(jviews)):
                         check(isinstance(v, dict))
-                        self.views[v]._from_json(data[v])
-                except RuntimeError as e:
-                    print(e)
+                        self.views[v]._from_json(jviews[v])
+                    self.view_idx = jidx
+                except Exception:
+                    print("{} is corrupted".format(self.file_name))
+                    self.__reset()
+        self.__services.ev_manager.post(PersistentStateLoadedEvent())
     
     def __save(self) -> None:
-        pass
-
-    def __colour_callback(self, colour: DynamicColour) -> None:
-        self.__services.ev_manager.post(ColourUpdateEvent(colour))
+        data = {}
+        data["view_index"] = self.view_idx
+        data["views"] = [self.views[v]._to_json() for v in range(self.MAX_VIEWS)]
+        with open(self.file_name, 'w') as f:
+            json.dump(self.views, f, sort_keys=True, indent=4)
+    
+    def __schedule_save(self) -> None:
+        w = self._services.graphics.window
+        if w is not None:
+            tm = w.taskMgr
+            name = "save_persistent_state"
+            if len(tm.getTasksNamed(name)) == 0:
+                tm.doMethodLater(5, lambda _: self.__save(), name)
+        else:
+            self.__save()
 
     def add_colour(self, name: str, default_colour: Colour, default_visible: bool = True) -> DynamicColour:
-        if name in self.colours:
-            return self.colours[name]
+        if name in self.effective_view.colours:
+            return self.effective_view.colours[name]
         
-        dc = self.colours[name] = DynamicColour(default_colour, name, self.__colour_callback, default_visible)
-        for v in range(len(self.views)):
+        dc = self.effective_view._add_colour(name, default_colour, default_visible)
+        for v in range(self.MAX_VIEWS):
             self.views[v]._add_colour(name, default_colour, default_visible)
-        callback(dc)
+        self.__schedule_save()
         return dc
 
     @property
@@ -110,8 +143,7 @@ class PersistentState(Model):
     @view_idx.setter
     def view_idx(self, idx: int) -> None:
         self.__view_idx = idx
-        for n, c in self.views[idx].colours.items():
-            self.colours[n].set_all(c.colour, c.visible)
+        self.effective_view._from_view(self.views[idx])
 
     @property
     def view(self) -> str:
@@ -124,7 +156,4 @@ class PersistentState(Model):
     @view.setter
     def view(self, v: View) -> None:
         assert v == self.views[v.index], "View is not owned by this PersistentState"
-
-        self.__view_idx = v.index
-        for n, c in v.colours.items():
-            self.colours[n].set_all(c.colour, c.visible)
+        self.view_idx = v.index

--- a/src/simulator/services/event_manager/event_manager.py
+++ b/src/simulator/services/event_manager/event_manager.py
@@ -65,9 +65,17 @@ class EventManager:
         :param event: The event to post
         """
 
+        # unify event with an existing one if
+        # allowed -> prevents spamming of events.
+        if event._unifiable:
+            for e in self.__event_queue:
+                if type(e) == type(event):
+                    e._absorb(event)
+                    return
+
         self.__event_queue.append(event)
         self.__services.debug.write(str(event), DebugLevel.MEDIUM)
-
+        
     def tick(self) -> None:
         """
         Sends all messages form the event queue

--- a/src/simulator/services/event_manager/event_manager.py
+++ b/src/simulator/services/event_manager/event_manager.py
@@ -75,7 +75,7 @@ class EventManager:
 
         self.__event_queue.append(event)
         self.__services.debug.write(str(event), DebugLevel.MEDIUM)
-        
+
     def tick(self) -> None:
         """
         Sends all messages form the event queue

--- a/src/simulator/services/event_manager/events/colour_update_event.py
+++ b/src/simulator/services/event_manager/events/colour_update_event.py
@@ -1,0 +1,24 @@
+from simulator.services.event_manager.events.event import Event
+from structures import DynamicColour
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from simulator.services.persistent_state import PersistentStateView
+
+class ColourUpdateEvent(Event):
+    __colour: DynamicColour
+    __view: 'PersistentStateView'
+
+    def __init__(self, colour: DynamicColour, view: 'PersistentStateView') -> None:
+        super().__init__()
+        self._name = "KeyFrame event"
+        self.__colour = colour
+        self.__view = view
+
+    @property
+    def colour(self) -> DynamicColour:
+        return self.__colour
+
+    @property
+    def view(self) -> 'PersistentStateView':
+        return self.__view

--- a/src/simulator/services/event_manager/events/colour_update_event.py
+++ b/src/simulator/services/event_manager/events/colour_update_event.py
@@ -10,8 +10,7 @@ class ColourUpdateEvent(Event):
     __view: 'PersistentStateView'
 
     def __init__(self, colour: DynamicColour, view: 'PersistentStateView') -> None:
-        super().__init__()
-        self._name = "KeyFrame event"
+        super().__init__("KeyFrame event")
         self.__colour = colour
         self.__view = view
 

--- a/src/simulator/services/event_manager/events/colour_update_event.py
+++ b/src/simulator/services/event_manager/events/colour_update_event.py
@@ -10,7 +10,7 @@ class ColourUpdateEvent(Event):
     __view: 'PersistentStateView'
 
     def __init__(self, colour: DynamicColour, view: 'PersistentStateView') -> None:
-        super().__init__("KeyFrame event")
+        super().__init__("ColourUpdate event")
         self.__colour = colour
         self.__view = view
 

--- a/src/simulator/services/event_manager/events/event.py
+++ b/src/simulator/services/event_manager/events/event.py
@@ -4,9 +4,15 @@ class Event:
     object and sent to the EventManager.
     """
     _name: str
+    _unifiable: bool
 
-    def __init__(self) -> None:
-        self._name = "Generic event"
+    def __init__(self, name: str = "Generic event", unifiable: bool = False) -> None:
+        self._name = name
+        self._unifiable = unifiable
 
     def __str__(self) -> str:
         return self._name
+
+    def _absorb(self, other: 'Event') -> None:
+        assert type(other) == type(self)
+        assert self._unifiable

--- a/src/simulator/services/event_manager/events/initialise_event.py
+++ b/src/simulator/services/event_manager/events/initialise_event.py
@@ -11,5 +11,4 @@ class InitialiseEvent(Event):
     """
 
     def __init__(self) -> None:
-        super().__init__()
-        self._name = "Initialise event"
+        super().__init__("Initialise event")

--- a/src/simulator/services/event_manager/events/key_frame_event.py
+++ b/src/simulator/services/event_manager/events/key_frame_event.py
@@ -7,8 +7,7 @@ class KeyFrameEvent(Event):
     __refresh: bool
 
     def __init__(self, is_first: bool = False, refresh: Optional[bool] = None) -> None:
-        super().__init__()
-        self._name = "KeyFrame event"
+        super().__init__("KeyFrame event", True)
         self.__is_first = is_first
         if refresh is None:
             self.__refresh = self.is_first

--- a/src/simulator/services/event_manager/events/new_colour_event.py
+++ b/src/simulator/services/event_manager/events/new_colour_event.py
@@ -1,0 +1,13 @@
+from simulator.services.event_manager.events.event import Event
+from structures import DynamicColour
+
+class NewColourEvent(Event):
+    __colour: DynamicColour
+
+    def __init__(self, colour: DynamicColour) -> None:
+        super().__init__("NewColour event")
+        self.__colour = colour
+
+    @property
+    def colour(self) -> DynamicColour:
+        return self.__colour

--- a/src/simulator/services/event_manager/events/quit_event.py
+++ b/src/simulator/services/event_manager/events/quit_event.py
@@ -7,5 +7,4 @@ class QuitEvent(Event):
     """
 
     def __init__(self) -> None:
-        super().__init__()
-        self._name = "Quit event"
+        super().__init__("Quit event", True)

--- a/src/simulator/services/event_manager/events/take_screenshot_event.py
+++ b/src/simulator/services/event_manager/events/take_screenshot_event.py
@@ -3,5 +3,4 @@ from simulator.services.event_manager.events.event import Event
 
 class TakeScreenshotEvent(Event):
     def __init__(self) -> None:
-        super().__init__()
-        self._name = "TakeScreenshot event"
+        super().__init__("TakeScreenshot event", True)

--- a/src/simulator/services/persistent_state.py
+++ b/src/simulator/services/persistent_state.py
@@ -24,7 +24,7 @@ class PersistentStateView():
         self.index = index
 
         self.colours = {}
-    
+
     def __colour_callback(self, colour: DynamicColour) -> None:
         if self.index == self.state.view_idx:
             self.state.effective_view.colours[colour.name].set_all(colour.colour, colour.visible)
@@ -73,17 +73,17 @@ class PersistentState(Service):
     __view_idx: int
 
     _save_task: Optional['Task']
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **exclude_from_dict(kwargs, ["file_name"]))
         self.file_name = kwargs["file_name"] if "file_name" in kwargs else ".pathbench.json"
-        
+
         self._save_task = None
 
         self.reset(False)
         self.load()
         self.save()
-        
+
     def reset(self, save: bool = True) -> None:
         self.effective_view = PersistentStateView(self._services, self, PersistentStateView.EFFECTIVE_VIEW)
         self.views = [PersistentStateView(self._services, self, i) for i in range(self.MAX_VIEWS)]
@@ -95,10 +95,10 @@ class PersistentState(Service):
         def check(req: bool) -> None:
             if not req:
                 raise RuntimeError
-        
+
         if os.path.isfile(self.file_name):
             self._services.debug.write("Loading state from '{}'".format(self.file_name), DebugLevel.BASIC)
-            with open(self.file_name, 'r') as f:                
+            with open(self.file_name, 'r') as f:
                 try:
                     jdata = json.load(f)
                     jidx = jdata["view_index"]
@@ -112,7 +112,7 @@ class PersistentState(Service):
                     self.reset()
         else:
             self._services.debug.write("'{}' not found, falling back to default state data".format(self.file_name), DebugLevel.BASIC)
-    
+
     def save(self) -> None:
         self._services.debug.write("Saving state to '{}'".format(self.file_name), DebugLevel.BASIC)
         data = {}
@@ -120,7 +120,7 @@ class PersistentState(Service):
         data["views"] = [self.views[v]._to_json() for v in range(self.MAX_VIEWS)]
         with open(self.file_name, 'w') as f:
             json.dump(data, f, sort_keys=True, indent=4)
-        
+
         if self._save_task is not None:
             self._services.graphics.window.taskMgr.remove(self._save_task)
             self._save_task = None
@@ -128,7 +128,7 @@ class PersistentState(Service):
     def schedule_save(self, delay: float = 0) -> None:
         if delay < 0:
             return
-        
+
         if delay > 0 and self._services.graphics is not None:
             tm = self._services.graphics.window.taskMgr
             if self._save_task is None:
@@ -140,7 +140,7 @@ class PersistentState(Service):
     def add_colour(self, name: str, default_colour: Colour, default_visible: bool = True, save_delay: float = 0) -> DynamicColour:
         if name in self.effective_view.colours:
             return self.effective_view.colours[name]
-        
+
         dc = self.effective_view._add_colour(name, default_colour, default_visible)
         for v in range(self.MAX_VIEWS):
             self.views[v]._add_colour(name, default_colour, default_visible)
@@ -157,11 +157,11 @@ class PersistentState(Service):
     @property
     def view_idx(self) -> str:
         return 'view_idx'
-    
+
     @view_idx.getter
     def view_idx(self) -> int:
         return self.__view_idx
-    
+
     @view_idx.setter
     def view_idx(self, value: Any) -> None:
         idx, save_delay = (value, 4.0) if isinstance(value, int) else value
@@ -176,7 +176,7 @@ class PersistentState(Service):
     @view.getter
     def view(self) -> PersistentStateView:
         return self.views[self.view_idx]
-    
+
     @view.setter
     def view(self, v: PersistentStateView) -> None:
         assert v == self.views[v.index], "PersistentStateView is not owned by this PersistentState"

--- a/src/simulator/services/persistent_state.py
+++ b/src/simulator/services/persistent_state.py
@@ -38,8 +38,12 @@ class PersistentStateView():
         return dc
 
     def _from_view(self, other: 'PersistentStateView') -> None:
+        self.colours = dict(filter(lambda n: n in other.colours, self.colours))
         for n, c in other.colours.items():
-            self.colours[n].set_all(c.colour, c.visible)
+            if n not in self.colours:
+                self._add_colour(n, c.colour, c.visible)
+            else:
+                self.colours[n].set_all(c.colour, c.visible)
 
     def _from_json(self, data: Dict[str, Any]) -> None:
         for n, c in data["colours"].items():
@@ -129,6 +133,13 @@ class PersistentState(Service):
             self.views[v]._add_colour(name, default_colour, default_visible)
         self.__schedule_save()
         return dc
+
+    def restore_effective_view(self):
+        self.effective_view._from_view(self.view)
+
+    def apply_effective_view(self):
+        self.view._from_view(self.effective_view)
+        self.__schedule_save()
 
     @property
     def view_idx(self) -> str:

--- a/src/simulator/services/persistent_state.py
+++ b/src/simulator/services/persistent_state.py
@@ -3,6 +3,7 @@ from structures import DynamicColour, Colour, TRANSPARENT
 from simulator.services.service import Service
 from simulator.services.services import Services
 from simulator.services.event_manager.events.colour_update_event import ColourUpdateEvent
+from simulator.services.event_manager.events.new_colour_event import NewColourEvent
 from simulator.services.debug import DebugLevel
 from utility.utils import exclude_from_dict
 
@@ -143,6 +144,7 @@ class PersistentState(Service):
         dc = self.effective_view._add_colour(name, default_colour, default_visible)
         for v in range(self.MAX_VIEWS):
             self.views[v]._add_colour(name, default_colour, default_visible)
+        self._services.ev_manager.post(NewColourEvent(dc))
         self.schedule_save(save_delay)
         return dc
 

--- a/src/simulator/services/persistent_state.py
+++ b/src/simulator/services/persistent_state.py
@@ -3,9 +3,10 @@ from structures import DynamicColour, Colour, TRANSPARENT
 from simulator.services.service import Service
 from simulator.services.services import Services
 from simulator.services.event_manager.events.colour_update_event import ColourUpdateEvent
+from simulator.services.debug import DebugLevel
 from utility.utils import exclude_from_dict
 
-from typing import Dict, Final, Any, List
+from typing import Dict, Final, Any, List, Optional
 import json
 import os
 
@@ -70,72 +71,88 @@ class PersistentState(Service):
     effective_view: PersistentStateView
     views: List[PersistentStateView]
     __view_idx: int
+
+    _save_task: Optional['Task']
     
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **exclude_from_dict(kwargs, ["file_name"]))
         self.file_name = kwargs["file_name"] if "file_name" in kwargs else ".pathbench.json"
+        
+        self._save_task = None
 
-        self.__reset()
-        self.__load()
-        self.__save()
-    
-    def __reset(self):
+        self.reset(False)
+        self.load()
+        self.save()
+        
+    def reset(self, save: bool = True) -> None:
         self.effective_view = PersistentStateView(self._services, self, PersistentStateView.EFFECTIVE_VIEW)
         self.views = [PersistentStateView(self._services, self, i) for i in range(self.MAX_VIEWS)]
         self.__view_idx = 0
+        if save:
+            self.save()
 
-    def __load(self) -> None:
+    def load(self) -> None:
         def check(req: bool) -> None:
             if not req:
                 raise RuntimeError
-
+        
         if os.path.isfile(self.file_name):
+            self._services.debug.write("Loading state from '{}'".format(self.file_name), DebugLevel.BASIC)
             with open(self.file_name, 'r') as f:                
                 try:
                     jdata = json.load(f)
                     jidx = jdata["view_index"]
                     check(jidx >= 0 and jidx < self.MAX_VIEWS)
                     jviews = jdata["views"]
-                    check(len(jviews) == self.MAX_VIEWS)
-                    for v in range(len(jviews)):
+                    for v in range(self.MAX_VIEWS):
                         self.views[v]._from_json(jviews[v])
                     self.view_idx = jidx
                 except Exception:
                     print("{} is corrupted".format(self.file_name))
-                    self.__reset()
+                    self.reset()
+        else:
+            self._services.debug.write("'{}' not found, falling back to default state data".format(self.file_name), DebugLevel.BASIC)
     
-    def __save(self) -> None:
+    def save(self) -> None:
+        self._services.debug.write("Saving state to '{}'".format(self.file_name), DebugLevel.BASIC)
         data = {}
         data["view_index"] = self.view_idx
         data["views"] = [self.views[v]._to_json() for v in range(self.MAX_VIEWS)]
         with open(self.file_name, 'w') as f:
             json.dump(data, f, sort_keys=True, indent=4)
-    
-    def __schedule_save(self) -> None:
-        if self._services.graphics is not None:
-            tm = self._services.graphics.window.taskMgr
-            name = "save_persistent_state"
-            if len(tm.getTasksNamed(name)) == 0:
-                tm.doMethodLater(5, lambda _: self.__save(), name)
-        else:
-            self.__save()
+        
+        if self._save_task is not None:
+            self._services.graphics.window.taskMgr.remove(self._save_task)
+            self._save_task = None
 
-    def add_colour(self, name: str, default_colour: Colour, default_visible: bool = True) -> DynamicColour:
+    def schedule_save(self, delay: float = 0) -> None:
+        if delay < 0:
+            return
+        
+        if delay > 0 and self._services.graphics is not None:
+            tm = self._services.graphics.window.taskMgr
+            if self._save_task is None:
+                self._services.debug.write("Scheduling state save to be executed {} seconds from now".format(delay), DebugLevel.BASIC)
+                self._save_task = tm.doMethodLater(delay, lambda _: self.save(), "save_persistent_state")
+        else:
+            self.save()
+
+    def add_colour(self, name: str, default_colour: Colour, default_visible: bool = True, save_delay: float = 0) -> DynamicColour:
         if name in self.effective_view.colours:
             return self.effective_view.colours[name]
         
         dc = self.effective_view._add_colour(name, default_colour, default_visible)
         for v in range(self.MAX_VIEWS):
             self.views[v]._add_colour(name, default_colour, default_visible)
-        self.__schedule_save()
+        self.schedule_save(save_delay)
         return dc
 
     def restore_effective_view(self):
         self.effective_view._from_view(self.view)
 
-    def apply_effective_view(self):
+    def apply_effective_view(self, save_delay: float = 0):
         self.view._from_view(self.effective_view)
-        self.__schedule_save()
+        self.schedule_save(save_delay)
 
     @property
     def view_idx(self) -> str:
@@ -146,9 +163,11 @@ class PersistentState(Service):
         return self.__view_idx
     
     @view_idx.setter
-    def view_idx(self, idx: int) -> None:
+    def view_idx(self, value: Any) -> None:
+        idx, save_delay = (value, 4.0) if isinstance(value, int) else value
         self.__view_idx = idx
         self.effective_view._from_view(self.views[idx])
+        self.schedule_save(save_delay)
 
     @property
     def view(self) -> str:

--- a/src/simulator/services/persistent_state.py
+++ b/src/simulator/services/persistent_state.py
@@ -94,14 +94,11 @@ class PersistentState(Service):
             with open(self.file_name, 'r') as f:                
                 try:
                     jdata = json.load(f)
-                    check(isinstance(jdata, dict))
                     jidx = jdata["view_index"]
                     check(jidx >= 0 and jidx < self.MAX_VIEWS)
                     jviews = jdata["views"]
-                    check(isinstance(jviews, list))
                     check(len(jviews) == self.MAX_VIEWS)
                     for v in range(len(jviews)):
-                        check(isinstance(v, dict))
                         self.views[v]._from_json(jviews[v])
                     self.view_idx = jidx
                 except Exception:

--- a/src/simulator/services/persistent_state.py
+++ b/src/simulator/services/persistent_state.py
@@ -60,7 +60,6 @@ class PersistentStateView():
             dc[n]["visible"] = c.visible
         return data
 
-    @property
     def is_effective(self) -> bool:
         return self.index == PersistentStateView.EFFECTIVE_VIEW
 

--- a/src/simulator/services/services.py
+++ b/src/simulator/services/services.py
@@ -16,9 +16,9 @@ class Services:
     This class is a bag of services available throughout all simulator classes and algorithms
     """
     __settings: 'Configuration'
-    __state: 'PersistentState'
     __debug: Debug
     __ev_manager: EventManager
+    __state: 'PersistentState'
     __algorithm_runner: 'AlgorithmRunner'
     __graphics: Optional['GraphicsManager']
     __resources_dir: 'Resources'
@@ -26,9 +26,9 @@ class Services:
 
     def __init__(self, config: 'Configuration') -> None:
         self.__settings = None
-        self.__state = None
         self.__debug = None
         self.__ev_manager = None
+        self.__state = None
         self.__graphics = None
         self.__algorithm_runner = None
         self.__resources_dir = None
@@ -43,9 +43,9 @@ class Services:
         from simulator.services.torch import Torch
 
         self.__settings = config
-        self.__state = PersistentState(self)
         self.__debug = Debug(self)
         self.__ev_manager = EventManager(self)
+        self.__state = PersistentState(self)
         self.__resources_dir = Resources(self)
         self.__torch = Torch(self)
         self.__algorithm_runner = AlgorithmRunner(self)

--- a/src/simulator/services/services.py
+++ b/src/simulator/services/services.py
@@ -16,6 +16,7 @@ class Services:
     This class is a bag of services available throughout all simulator classes and algorithms
     """
     __settings: 'Configuration'
+    __state: 'PersistentState'
     __debug: Debug
     __ev_manager: EventManager
     __algorithm_runner: 'AlgorithmRunner'
@@ -25,6 +26,7 @@ class Services:
 
     def __init__(self, config: 'Configuration') -> None:
         self.__settings = None
+        self.__state = None
         self.__debug = None
         self.__ev_manager = None
         self.__graphics = None
@@ -37,9 +39,11 @@ class Services:
         from simulator.services.graphics.graphics_manager import GraphicsManager
         from simulator.services.algorithm_runner import AlgorithmRunner
         from simulator.services.resources.resources import Resources
+        from simulator.services.persistent_state import PersistentState
         from simulator.services.torch import Torch
 
         self.__settings = config
+        self.__state = PersistentState(self)
         self.__debug = Debug(self)
         self.__ev_manager = EventManager(self)
         self.__resources_dir = Resources(self)
@@ -49,6 +53,14 @@ class Services:
 
         if self.__settings.simulator_graphics:
             self.__graphics = GraphicsManager(self)
+
+    @property
+    def state(self) -> str:
+        return 'state'
+
+    @state.getter
+    def state(self) -> 'PersistentState':
+        return self.__state
 
     @property
     def debug(self) -> str:

--- a/src/simulator/views/gui/view_editor.py
+++ b/src/simulator/views/gui/view_editor.py
@@ -761,10 +761,10 @@ class ViewEditor():
         self.__services.state.apply_effective_view()
     
     def __update_visibility(self, name: str, visible: bool) -> None:
-        self.__services.state.effective_view.colours[n].visible = visible
+        self.__services.state.effective_view.colours[name].visible = visible
 
     def __update_colour(self, name: str, colour: Colour) -> None:
-        self.__services.state.effective_view.colours[n].colour = colour
+        self.__services.state.effective_view.colours[name].colour = colour
 
     def __toggle_view_editor(self):
         if not self.hidden:

--- a/src/simulator/views/gui/view_editor.py
+++ b/src/simulator/views/gui/view_editor.py
@@ -237,7 +237,7 @@ class ColourView():
     @property
     def view(self) -> DirectFrame:
         return self.__view
-        
+
     def destroy(self) -> None:
         self.__view.destroy()
         self.__frame.destroy()
@@ -595,7 +595,7 @@ class ViewElement():
             self.__visibility_bar.hide()
         else:
             self.__visibility_bar.show()
-    
+
     def destroy(self) -> None:
         self.__visibility_bar.destroy()
         self.__visibility_btn.destroy()
@@ -616,7 +616,7 @@ class ViewEditor():
         self.__services = services
         self.__base = self.__services.graphics.window
         self.hidden = False
-        
+
         self.__window = Window(self.__base, "view_editor", parent=self.__base.pixel2d,
                                relief=DGG.RAISED,
                                borderWidth=(0.0, 0.0),
@@ -754,7 +754,7 @@ class ViewEditor():
 
         for i in range(len(self.__elems)):
             self.__elems[i].frame.set_pos((0.0, 0.0, -1.9 - 0.2 * i))
-        
+
         if self.view_idx < 3:
             self.__selected_view_outline.set_pos((-0.7 + self.view_idx * 0.7, 0.4, -4.4))
         else:
@@ -764,7 +764,7 @@ class ViewEditor():
 
     def __save(self) -> None:
         self.__services.state.apply_effective_view()
-    
+
     def __update_visibility(self, name: str, visible: bool) -> None:
         self.__services.state.effective_view.colours[name].visible = visible
 
@@ -782,7 +782,7 @@ class ViewEditor():
     def __colour_picker_callback(self, colour: Colour) -> None:
         if self.__selected_cv_elem is None:
             return
-        self.__selected_cv_elem.colour = colour # calls self.__update_colour()
+        self.__selected_cv_elem.colour = colour  # calls self.__update_colour()
 
     def __select_cv(self, e: ViewElement):
         self.__selected_cv_elem = e
@@ -803,7 +803,7 @@ class ViewEditor():
     def view_idx(self, idx: int) -> None:
         self.__services.state.view_idx = idx
         self.__reset()
-    
+
     @view_idx.getter
     def view_idx(self) -> int:
         return self.__services.state.view_idx

--- a/src/simulator/views/gui/view_editor.py
+++ b/src/simulator/views/gui/view_editor.py
@@ -12,6 +12,7 @@ from structures import Colour, WHITE, BLACK, TRANSPARENT
 from constants import DATA_PATH
 
 from simulator.services.services import Services
+from simulator.services.event_manager.events.new_colour_event import NewColourEvent
 from simulator.views.gui.common import WINDOW_BG_COLOUR, WIDGET_BG_COLOUR
 
 class ColourPicker:
@@ -614,6 +615,7 @@ class ViewEditor():
 
     def __init__(self, services: Services):
         self.__services = services
+        self.__services.ev_manager.register_listener(self)
         self.__base = self.__services.graphics.window
         self.hidden = False
 
@@ -794,6 +796,10 @@ class ViewEditor():
             self.__selected_cv_outline.show()
             self.__selected_cv_outline.set_pos((-0.65, 1.0, -1.897 - 0.2 * self.__elems.index(e)))
             self.__colour_picker.colour = e.colour
+
+    def notify(self, event: Event) -> None:
+        if isinstance(event, NewColourEvent):
+            self.__reset()
 
     @property
     def view_idx(self) -> str:

--- a/src/simulator/views/gui/view_editor.py
+++ b/src/simulator/views/gui/view_editor.py
@@ -12,8 +12,6 @@ from structures import Colour, WHITE, BLACK, TRANSPARENT
 from constants import DATA_PATH
 
 from simulator.services.services import Services
-from simulator.views.map.data.voxel_map import VoxelMap
-
 from simulator.views.gui.common import WINDOW_BG_COLOUR, WIDGET_BG_COLOUR
 
 class ColourPicker:
@@ -28,9 +26,12 @@ class ColourPicker:
     __marker: DirectFrame
     __marker_center: DirectFrame
 
+    __enabled: bool
+
     def __init__(self, base: ShowBase, pick_colour_callback: Callable[[Tuple[float, float, float, float]], None], **kwargs) -> None:
         self.__base = base
         self.pick_colour_callback = pick_colour_callback
+        self.__enabled = True
 
         # PALETTE #
         palette_filename = os.path.join(DATA_PATH, "colour_palette.png")
@@ -126,8 +127,9 @@ class ColourPicker:
         return self.__colour_at(pointer.getX(), -pointer.getY())
 
     def __pick(self, *args):
-        self.__update_marker_pos()
-        self.pick_colour_callback(self.__update_marker_colour())
+        if self.__enabled:
+            self.__update_marker_pos()
+            self.pick_colour_callback(self.__update_marker_colour())
 
     @property
     def frame(self) -> DirectFrame:
@@ -137,6 +139,11 @@ class ColourPicker:
     def marker(self) -> DirectFrame:
         return self.__marker
 
+    def enable(self) -> None:
+        self.__enabled = True
+
+    def disable(self) -> None:
+        self.__enabled = False
 
 class Window():
     __base: ShowBase
@@ -227,6 +234,10 @@ class ColourView():
     def frame(self) -> DirectFrame:
         return self.__frame
 
+    def destroy(self) -> None:
+        self.__view.destroy()
+        self.__frame.destroy()
+
 
 class ColourChannel():
     __slider_edit_callback: Callable[['ColourChannel', float], None]
@@ -236,6 +247,8 @@ class ColourChannel():
     __label: DirectLabel
     __slider: DirectSlider
     __entry: DirectEntry
+    __disable_frame_overlay: DirectButton
+    __enabled: bool
 
     def __init__(self, parent: DirectFrame, text: str, value: float, slider_edit_callback: Callable[['ColourChannel', float], None], entry_edit_callback: Callable[['ColourChannel', float], None]):
         self.__frame = DirectFrame(parent=parent)
@@ -267,6 +280,13 @@ class ColourChannel():
                                    width=3,
                                    pos=(0.55, 0.0, -0.01105))
 
+        self.__disable_frame_overlay = DirectButton(parent=self.__frame,
+                                                    frameColor=TRANSPARENT,
+                                                    borderWidth=(0.0, 0.0),
+                                                    frameSize=(-0.6, 0.9, -0.2, 0.2),
+                                                    suppressMouse=True)
+        self.__enabled = True
+
         self.__set_callbacks()
 
     def __unset_callbacks(self):
@@ -282,11 +302,15 @@ class ColourChannel():
         return self.__frame
 
     def update_slider(self, value: float):
+        if not self.__enabled:
+            return
         self.__unset_callbacks()
         self.__slider['value'] = value
         self.__set_callbacks()
 
     def update_entry(self, value: float):
+        if not self.__enabled:
+            return
         self.__unset_callbacks()
         self.__entry.enterText(f'{value:.3f}')
         self.__set_callbacks()
@@ -299,6 +323,18 @@ class ColourChannel():
     def value(self) -> float:
         return self.__slider['value']
 
+    def enable(self) -> None:
+        if self.__enabled:
+            return
+        self.__enabled = True
+        self.__disable_frame_overlay.hide()
+
+    def disable(self) -> None:
+        if not self.__enabled:
+            return
+        self.__enabled = False
+        self.__disable_frame_overlay.show()
+
 
 class AdvancedColourPicker():
     __base: ShowBase
@@ -307,11 +343,20 @@ class AdvancedColourPicker():
 
     __frame: DirectFrame
     __colour_picker: ColourPicker
+    __cv_picked: ColourView
+    __cv_hovered: ColourView
+    __r: ColourChannel
+    __g: ColourChannel
+    __b: ColourChannel
+    __a: ColourChannel
+    __dirty_rem_no_hide: int
+    __enabled: bool
 
     def __init__(self, base: ShowBase, parent: DirectFrame, callback: Callable[[Colour], None], colour: Colour = Colour(0.25, 0.5, 0.75, 1.0)):
         self.__base = base
         self.__colour = colour
         self.__callback = callback
+        self.__enabled = True
 
         self.__frame = DirectFrame(parent=parent)
 
@@ -410,28 +455,61 @@ class AdvancedColourPicker():
         self.__b.update(b)
         self.__a.update(a)
 
+    def enable(self) -> None:
+        if self.__enabled:
+            return
+        self.__enabled = True
+        self.__colour_picker.enable()
+        self.__r.enable()
+        self.__g.enable()
+        self.__b.enable()
+        self.__a.enable()
+
+    def disable(self) -> None:
+        if not self.__enabled:
+            return
+        self.__enabled = False
+        self.colour = WINDOW_BG_COLOUR
+        self.__colour_picker.disable()
+        self.__r.disable()
+        self.__g.disable()
+        self.__b.disable()
+        self.__a.disable()
+
 class ViewElement():
     __name: str
     __visibility_callback: Callable[[str, bool], None]
     __colour_callback: Callable[[str, Colour], None]
+    __cv_clicked_callback: Callable[['ViewElement'], None]
     __visible: bool
 
     __frame: DirectFrame
     __label: DirectLabel
     __cv: ColourView
-    __visibility_btn: DirectFrame
+    __cv_btn: DirectButton
+    __visibility_btn: DirectButton
+    __visibility_bar: DirectFrame
 
-    def __init__(self, name: str, visibility_callback: Callable[[str, bool], None], colour_callback: Callable[[str, Colour], None], parent: DirectFrame, visible: bool = True, colour: Colour = Colour(0.2, 0.3, 0.4, 0.5)):
+    def __init__(self, name: str, visibility_callback: Callable[[str, bool], None], colour_callback: Callable[[str, Colour], None], cv_clicked_callback: Callable[['ViewElement'], None], parent: DirectFrame, visible: bool = True, colour: Colour = Colour(0.2, 0.3, 0.4, 0.5)):
         self.__name = name
         self.__visible = visible
         self.__visibility_callback = None
         self.__colour_callback = None
+        self.__cv_clicked_callback = None
 
         self.__frame = DirectFrame(parent=parent, frameColor=WINDOW_BG_COLOUR)
 
         self.__cv = ColourView(self.__frame, colour)
         self.__cv.frame.set_scale((0.15, 1.0, 0.15))
         self.__cv.frame.set_pos((-0.65, 1.0, 0.0))
+
+        self.__cv_btn = DirectButton(parent=self.__frame,
+                                     frameColor=TRANSPARENT,
+                                     borderWidth=(0, 0),
+                                     frameSize=self.__cv.frame["frameSize"],
+                                     scale=self.__cv.frame["scale"],
+                                     pos=self.__cv.frame["pos"],
+                                     command=self.__cv_clicked)
 
         self.__label = DirectLabel(parent=self.__frame,
                                    text=self.__name,
@@ -460,9 +538,14 @@ class ViewElement():
 
         self.__visibility_callback = visibility_callback
         self.__colour_callback = colour_callback
+        self.__cv_clicked_callback = cv_clicked_callback
 
     def __toggle_visible(self):
         self.visible = not self.visible
+
+    def __cv_clicked(self):
+        if self.__cv_clicked_callback:
+            self.__cv_clicked_callback(self)
 
     @property
     def name(self) -> str:
@@ -507,22 +590,28 @@ class ViewElement():
             self.__visibility_bar.hide()
         else:
             self.__visibility_bar.show()
+    
+    def destroy(self) -> None:
+        self.__visibility_bar.destroy()
+        self.__visibility_btn.destroy()
+        self.__cv_btn.destroy()
+        self.__cv.destroy()
+        self.__label.destroy()
+        self.__frame.destroy()
+
 
 class ViewEditor():
     __services: Services
     __base: ShowBase
     __window: Window
     __colour_picker: AdvancedColourPicker
-    __elements: List[ViewElement]
-    __voxel_map: VoxelMap
+    __elems: List[ViewElement]
 
-    def __init__(self, services: Services, voxel_map: VoxelMap):
+    def __init__(self, services: Services):
         self.__services = services
         self.__base = self.__services.graphics.window
-        self.__voxel_map = voxel_map
         self.hidden = False
-
-        self.state_num = 0
+        
         self.__window = Window(self.__base, "view_editor", parent=self.__base.pixel2d,
                                relief=DGG.RAISED,
                                borderWidth=(0.0, 0.0),
@@ -559,8 +648,8 @@ class ViewEditor():
                                                  borderWidth=(0.15, 0.15),
                                                  frameSize=(-0.62, 0.62, -0.54, 0.54),
                                                  scale=(0.18, 1.0, 0.18))
-        # selected state number frame
-        self.__selected_state_number = DirectFrame(parent=self.__window.frame,
+        # selected view frame
+        self.__selected_view_outline = DirectFrame(parent=self.__window.frame,
                                                    relief=DGG.SUNKEN,
                                                    frameColor=WHITE,
                                                    borderWidth=(0.15, 0.15),
@@ -572,15 +661,11 @@ class ViewEditor():
                                    text_fg=WHITE,
                                    text_bg=WINDOW_BG_COLOUR,
                                    borderWidth=(.0, .0),
-                                   #pos=(10.9, 1.4, 3),
+                                   pos=(0.0, 0.0, 1.27),
                                    scale=(0.2, 3, 0.2))
 
-        self.heading.set_pos((0.0, 0.0, 1.27))
-
-        quit_filename = os.path.join(DATA_PATH, "quit.png")
-
         # Quit button
-        self.btn = DirectButton(image=quit_filename,
+        self.btn = DirectButton(image=os.path.join(DATA_PATH, "quit.png"),
                                 command=self.__toggle_view_editor,
                                 pos=(0.9, 0.4, 1.32),
                                 parent=self.__window.frame,
@@ -610,7 +695,7 @@ class ViewEditor():
             text="Save",
             text_fg=(0.3, 0.3, 0.3, 1.0),
             pressEffect=1,
-            command=lambda: self.save_state(self.state_num),
+            command=self.__save,
             pos=(-0.575, 0, -5.5),
             parent=self.__window.frame,
             scale=(0.20, 2.1, 0.15),
@@ -620,153 +705,66 @@ class ViewEditor():
             text="Restore",
             text_fg=(0.3, 0.3, 0.3, 1.0),
             pressEffect=1,
-            command=lambda: self.load_state(self.state_num),
+            command=self.__reset,
             pos=(0.50, 0, -5.5),
             parent=self.__window.frame,
             scale=(0.20, 2.1, 0.15),
             frameColor=TRANSPARENT)
 
-        # view elements
-        self.__elements = []
-        for name, dc in self.__voxel_map.colours.items():
-            self.__elements.append(ViewElement(name, self.__voxel_map.set_visibility, self.__voxel_map.set_colour, self.__window.frame, colour=dc()))
-
-        for i in range(len(self.__elements)):
-            self.__elements[i].frame.set_pos((0.0, 0.0, -1.9 - 0.2 * i))
-
-        self.__cv_transparent_overlays = []
-        for i in range(len(self.__elements)):
-            self.__cv_transparent_overlays.append(DirectButton(parent=self.__window.frame,
-                                                               relief=DGG.SUNKEN,
-                                                               frameColor=TRANSPARENT,
-                                                               borderWidth=(0, 0),
-                                                               frameSize=(-0.52, 0.52, -0.44, 0.44),
-                                                               scale=(0.18, 1.0, 0.18),
-                                                               pos=(-0.65, 1.0, -1.897 - 0.2 * i),
-                                                               command=self.__select_cv,
-                                                               extraArgs=[i]))
-
-        # Creating state buttons
-        self.__state_btns = []
+        # Creating view selectors
+        self.__view_selectors = []
         for i in range(0, 3):
             num = os.path.join(DATA_PATH, str(i + 1) + ".png")
 
-            self.__state_btns.append(DirectButton(image=num,
-                                                  pos=(-0.7 + i * 0.7, 0.4, -4.4),
-                                                  parent=self.__window.frame,
-                                                  scale=0.16,
-                                                  frameColor=TRANSPARENT,
-                                                  command=self.__select_state_num_one,
-                                                  extraArgs=[i]))
+            self.__view_selectors.append(DirectButton(image=num,
+                                                      pos=(-0.7 + i * 0.7, 0.4, -4.4),
+                                                      parent=self.__window.frame,
+                                                      scale=0.16,
+                                                      frameColor=TRANSPARENT,
+                                                      command=lambda v: setattr(self, "view_idx", v),
+                                                      extraArgs=[i]))
         for i in range(0, 3):
             num = os.path.join(DATA_PATH, str(i + 4) + ".png")
-            self.__state_btns.append(DirectButton(image=num,
-                                                  pos=(-0.7 + i * 0.7, 0.4, -4.9),
-                                                  parent=self.__window.frame,
-                                                  scale=0.16,
-                                                  frameColor=TRANSPARENT,
-                                                  command=self.__select_state_num_two,
-                                                  extraArgs=[i+3]))
+            self.__view_selectors.append(DirectButton(image=num,
+                                                      pos=(-0.7 + i * 0.7, 0.4, -4.9),
+                                                      parent=self.__window.frame,
+                                                      scale=0.16,
+                                                      frameColor=TRANSPARENT,
+                                                      command=lambda v: setattr(self, "view_idx", v),
+                                                      extraArgs=[i+3]))
 
-        """
-        # default settings - testing #
-        self.OBSTACLES = self.__elements[0]
-        self.OBSTACLES_TRI_WF = self.__elements[1]
-        self.OBSTACLES_SQR_WF = self.__elements[2]
-        self.TRAVERSABLES = self.__elements[3]
-        self.TRAVERSABLES_TRI_WF = self.__elements[4]
-        self.TRAVERSABLES_SQR_WF = self.__elements[5]
-        self.START = self.__elements[6]
-        self.GOAL = self.__elements[7]
-        self.PATH = self.__elements[8]
-        self.FRINGE = self.__elements[9]
-        self.EXPLORED = self.__elements[10]
-        """
+        self.__elems = []
+        self.__reset()
 
-        self.views = [{'OBSTACLES': [0.9254902601242065, 0.0, 1.0, 0.5], 'OBSTACLES_TRI_WF': [1.0, 1.0, 1.0, 1.0],
-                       'OBSTACLES_SQR_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES': [1.0, 1.0, 1.0, 0.0],
-                       'TRAVERSABLES_TRI_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES_SQR_WF': [1.0, 1.0, 1.0, 0.5],
-                       'START': [0.8, 0.0, 0.0, 1.0], 'GOAL': [0.0, 0.9, 0.0, 1.0], 'PATH': [1.0, 1.0, 1.0, 0.5],
-                       'FRINGE': [0.2, 0.2, 0.8, 1.0], 'EXPLORED': [0.4, 0.4, 0.4, 1.0]},
+    def __reset(self) -> None:
+        self.__services.state.restore_effective_view()
+        ps_colours = self.__services.state.effective_view.colours
 
-                      {'OBSTACLES': [0.8, 0.2, 0.2, 1.0], 'OBSTACLES_TRI_WF': [1.0, 1.0, 1.0, 1.0],
-                       'OBSTACLES_SQR_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES': [1.0, 1.0, 1.0, 0.5],
-                       'TRAVERSABLES_TRI_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES_SQR_WF': [1.0, 1.0, 1.0, 0.5],
-                       'START': [0.5, 0.0, 0.5, 1.0], 'GOAL': [0.0, 1.0, 0.0, 0.5], 'PATH': [1.0, 1.0, 1.0, 0.5],
-                       'FRINGE': [0.2, 0.2, 0.8, 1.0], 'EXPLORED': [0.4, 0.4, 0.4, 1.0]},
+        for e in self.__elems:
+            e.destroy()
+        self.__elems.clear()
 
-                      {'OBSTACLES': [0.8, 0.2, 0.2, 1.0], 'OBSTACLES_TRI_WF': [1.0, 1.0, 1.0, 1.0],
-                       'OBSTACLES_SQR_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES': [1.0, 1.0, 1.0, 0.5],
-                       'TRAVERSABLES_TRI_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES_SQR_WF': [1.0, 1.0, 1.0, 0.5],
-                       'START': [0.5, 0.0, 0.5, 1.0], 'GOAL': [0.0, 1.0, 0.0, 0.5], 'PATH': [1.0, 1.0, 1.0, 0.5],
-                       'FRINGE': [0.2, 0.2, 0.8, 1.0], 'EXPLORED': [0.4, 0.4, 0.4, 1.0]},
+        for name, dc in ps_colours.items():
+            self.__elems.append(ViewElement(name, self.__update_visibility, self.__update_colour, self.__select_cv, self.__window.frame, dc.visible, dc.colour))
 
-                      {'OBSTACLES': [0.8, 0.2, 0.2, 1.0], 'OBSTACLES_TRI_WF': [1.0, 1.0, 1.0, 1.0],
-                       'OBSTACLES_SQR_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES': [1.0, 1.0, 1.0, 0.5],
-                       'TRAVERSABLES_TRI_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES_SQR_WF': [1.0, 1.0, 1.0, 0.5],
-                       'START': [0.5, 0.0, 0.5, 1.0], 'GOAL': [0.0, 1.0, 0.0, 0.5], 'PATH': [1.0, 1.0, 1.0, 0.5],
-                       'FRINGE': [0.2, 0.2, 0.8, 1.0], 'EXPLORED': [0.4, 0.4, 0.4, 1.0]},
-
-                      {'OBSTACLES': [0.8, 0.2, 0.2, 1.0], 'OBSTACLES_TRI_WF': [1.0, 1.0, 1.0, 1.0],
-                       'OBSTACLES_SQR_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES': [1.0, 1.0, 1.0, 0.5],
-                       'TRAVERSABLES_TRI_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES_SQR_WF': [1.0, 1.0, 1.0, 0.5],
-                       'START': [0.5, 0.0, 0.5, 1.0], 'GOAL': [0.0, 1.0, 0.0, 0.5], 'PATH': [1.0, 1.0, 1.0, 0.5],
-                       'FRINGE': [0.2, 0.2, 0.8, 1.0], 'EXPLORED': [0.4, 0.4, 0.4, 1.0]},
-
-                      {'OBSTACLES': [0.8, 0.2, 0.2, 1.0], 'OBSTACLES_TRI_WF': [1.0, 1.0, 1.0, 1.0],
-                       'OBSTACLES_SQR_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES': [1.0, 1.0, 1.0, 0.5],
-                       'TRAVERSABLES_TRI_WF': [1.0, 1.0, 1.0, 0.5], 'TRAVERSABLES_SQR_WF': [1.0, 1.0, 1.0, 0.5],
-                       'START': [0.5, 0.0, 0.5, 1.0], 'GOAL': [0.0, 1.0, 0.0, 0.5], 'PATH': [1.0, 1.0, 1.0, 0.5],
-                       'FRINGE': [0.2, 0.2, 0.8, 1.0], 'EXPLORED': [0.4, 0.4, 0.4, 1.0]}
-                      ]
-
-        if os.path.isfile('state.json'):
-            with open('state.json', 'r') as json_file:
-                self.views = json.load(json_file)
-                # todo: actually check that structure is the same
+        for i in range(len(self.__elems)):
+            self.__elems[i].frame.set_pos((0.0, 0.0, -1.9 - 0.2 * i))
+        
+        if self.view_idx < 3:
+            self.__selected_view_outline.set_pos((-0.7 + self.view_idx * 0.7, 0.4, -4.4))
         else:
-            self.save_state()
+            self.__selected_view_outline.set_pos((-0.7 + (self.view_idx - 3) * 0.7, 0.4, -4.9))
 
-        self.__selected_cv_idx = 0
-        self.__select_cv(0)
-        self.__selected_sn_idx = 0
-        self.__select_state_num_one(0)
+        self.__select_cv(self.__elems[0] if self.__elems else None)
 
-    def load_state(self, i: int):
-        state_nr = self.views[i]
-        """
-        self.OBSTACLES.colour = Colour(state_nr["OBSTACLES"][0], state_nr["OBSTACLES"][1], state_nr["OBSTACLES"][2], state_nr["OBSTACLES"][3])
-        self.OBSTACLES_TRI_WF.colour = Colour(state_nr["OBSTACLES_TRI_WF"][0], state_nr["OBSTACLES_TRI_WF"][1], state_nr["OBSTACLES_TRI_WF"][2], state_nr["OBSTACLES_TRI_WF"][3])
-        self.OBSTACLES_SQR_WF.colour = Colour(state_nr["OBSTACLES_SQR_WF"][0], state_nr["OBSTACLES_SQR_WF"][1], state_nr["OBSTACLES_SQR_WF"][2], state_nr["OBSTACLES_SQR_WF"][3])
-        self.TRAVERSABLES.colour = Colour(state_nr["TRAVERSABLES"][0], state_nr["TRAVERSABLES"][1], state_nr["TRAVERSABLES"][2], state_nr["TRAVERSABLES"][3])
-        self.TRAVERSABLES_TRI_WF.colour = Colour(state_nr["TRAVERSABLES_TRI_WF"][0], state_nr["TRAVERSABLES_TRI_WF"][1], state_nr["TRAVERSABLES_TRI_WF"][2], state_nr["TRAVERSABLES_TRI_WF"][3])
-        self.TRAVERSABLES_SQR_WF.colour = Colour(state_nr["TRAVERSABLES_SQR_WF"][0], state_nr["TRAVERSABLES_SQR_WF"][1], state_nr["TRAVERSABLES_SQR_WF"][2], state_nr["TRAVERSABLES_SQR_WF"][3])
-        self.START.colour = Colour(state_nr["START"][0], state_nr["START"][1], state_nr["START"][2], state_nr["START"][3])
-        self.GOAL.colour = Colour(state_nr["GOAL"][0], state_nr["GOAL"][1], state_nr["GOAL"][2], state_nr["GOAL"][3])
-        self.PATH.colour = Colour(state_nr["PATH"][0], state_nr["PATH"][1], state_nr["PATH"][2], state_nr["PATH"][3])
-        self.FRINGE.colour = Colour(state_nr["FRINGE"][0], state_nr["FRINGE"][1], state_nr["FRINGE"][2], state_nr["FRINGE"][3])
-        self.EXPLORED.colour = Colour(state_nr["EXPLORED"][0], state_nr["EXPLORED"][1], state_nr["EXPLORED"][2], state_nr["EXPLORED"][3])
-        """
+    def __save(self) -> None:
+        self.__services.state.apply_effective_view()
+    
+    def __update_visibility(self, name: str, visible: bool) -> None:
+        self.__services.state.effective_view.colours[n].visible = visible
 
-    def save_state(self, i=None):
-        if i is not None:
-            state_nr = self.views[i]
-            """
-            state_nr["OBSTACLES"][0],state_nr["OBSTACLES"][1],state_nr["OBSTACLES"][2],state_nr["OBSTACLES"][3] = self.OBSTACLES.colour
-            state_nr["OBSTACLES_TRI_WF"][0], state_nr["OBSTACLES_TRI_WF"][1], state_nr["OBSTACLES_TRI_WF"][2], state_nr["OBSTACLES_TRI_WF"][3] = self.OBSTACLES_TRI_WF.colour
-            state_nr["OBSTACLES_SQR_WF"][0], state_nr["OBSTACLES_SQR_WF"][1], state_nr["OBSTACLES_SQR_WF"][2], state_nr["OBSTACLES_SQR_WF"][3] = self.OBSTACLES_SQR_WF.colour
-            state_nr["TRAVERSABLES"][0], state_nr["TRAVERSABLES"][1], state_nr["TRAVERSABLES"][2], state_nr["TRAVERSABLES"][3] = self.TRAVERSABLES.colour
-            state_nr["TRAVERSABLES_TRI_WF"][0], state_nr["TRAVERSABLES_TRI_WF"][1], state_nr["TRAVERSABLES_TRI_WF"][2], state_nr["TRAVERSABLES_TRI_WF"][3] = self.TRAVERSABLES_TRI_WF.colour
-            state_nr["TRAVERSABLES_SQR_WF"][0], state_nr["TRAVERSABLES_SQR_WF"][1], state_nr["TRAVERSABLES_SQR_WF"][2], state_nr["TRAVERSABLES_SQR_WF"][3] = self.OBSTACLES_SQR_WF.colour
-            state_nr["START"][0], state_nr["START"][1], state_nr["START"][2], state_nr["START"][3] = self.START.colour
-            state_nr["GOAL"][0], state_nr["GOAL"][1], state_nr["GOAL"][2], state_nr["GOAL"][3] = self.GOAL.colour
-            state_nr["PATH"][0], state_nr["PATH"][1], state_nr["PATH"][2], state_nr["PATH"][3] = self.PATH.colour
-            state_nr["FRINGE"][0], state_nr["FRINGE"][1], state_nr["FRINGE"][2], state_nr["FRINGE"][3] = self.FRINGE.colour
-            state_nr["EXPLORED"][0], state_nr["EXPLORED"][1], state_nr["EXPLORED"][2], state_nr["EXPLORED"][3] = self.EXPLORED.colour
-            """
-
-        with open('state.json', 'w') as json_file:
-            json.dump(self.views, json_file)
+    def __update_colour(self, name: str, colour: Colour) -> None:
+        self.__services.state.effective_view.colours[n].colour = colour
 
     def __toggle_view_editor(self):
         if not self.hidden:
@@ -777,22 +775,30 @@ class ViewEditor():
             self.hidden = False
 
     def __colour_picker_callback(self, colour: Colour) -> None:
-        i = self.__selected_cv_idx
-        self.__elements[i].colour = colour
+        if self.__selected_cv_elem is None:
+            return
+        self.__selected_cv_elem.colour = colour # calls self.__update_colour()
 
-    def __select_cv(self, i: int):
-        self.__selected_cv_idx = i
-        self.__selected_cv_outline.set_pos((-0.65, 1.0, -1.897 - 0.2 * i))
-        self.__colour_picker.colour = self.__elements[i].colour
+    def __select_cv(self, e: ViewElement):
+        self.__selected_cv_elem = e
+        if e is None:
+            self.__selected_cv_outline.hide()
+            self.__colour_picker.disable()
+        else:
+            self.__colour_picker.enable()
+            self.__selected_cv_outline.show()
+            self.__selected_cv_outline.set_pos((-0.65, 1.0, -1.897 - 0.2 * self.__elems.index(e)))
+            self.__colour_picker.colour = e.colour
 
-    def __select_state_num_one(self, i: int):
-        self.__selected_sn_idx = i
-        self.__selected_state_number.set_pos((-0.7 + i * 0.7, 0.4, -4.4))
-        self.load_state(i)
-        self.state_num = i
+    @property
+    def view_idx(self) -> str:
+        return 'view_idx'
 
-    def __select_state_num_two(self, i: int):
-        self.__selected_sn_idx = i
-        self.__selected_state_number.set_pos((-0.7 + (i-3) * 0.7, 0.4, -4.9))
-        self.load_state(i)
-        self.state_num = i
+    @view_idx.setter
+    def view_idx(self, idx: int) -> None:
+        self.__services.state.view_idx = idx
+        self.__reset()
+    
+    @view_idx.getter
+    def view_idx(self) -> int:
+        return self.__services.state.view_idx

--- a/src/simulator/views/gui/view_editor.py
+++ b/src/simulator/views/gui/view_editor.py
@@ -12,6 +12,7 @@ from structures import Colour, WHITE, BLACK, TRANSPARENT
 from constants import DATA_PATH
 
 from simulator.services.services import Services
+from simulator.services.persistent_state import PersistentState
 from simulator.services.event_manager.events.new_colour_event import NewColourEvent
 from simulator.views.gui.common import WINDOW_BG_COLOUR, WIDGET_BG_COLOUR
 
@@ -727,25 +728,16 @@ class ViewEditor():
 
         # Creating view selectors
         self.__view_selectors = []
-        for i in range(0, 3):
+        for i in range(0, PersistentState.MAX_VIEWS):
             num = os.path.join(DATA_PATH, str(i + 1) + ".png")
 
             self.__view_selectors.append(DirectButton(image=num,
-                                                      pos=(-0.7 + i * 0.7, 0.4, -4.4),
+                                                      pos=(-0.7 + (i % 3) * 0.7, 0.4, -4.4 - 0.5 * (i // 3)),
                                                       parent=self.__window.frame,
                                                       scale=0.16,
                                                       frameColor=TRANSPARENT,
                                                       command=lambda v: setattr(self, "view_idx", v),
                                                       extraArgs=[i]))
-        for i in range(0, 3):
-            num = os.path.join(DATA_PATH, str(i + 4) + ".png")
-            self.__view_selectors.append(DirectButton(image=num,
-                                                      pos=(-0.7 + i * 0.7, 0.4, -4.9),
-                                                      parent=self.__window.frame,
-                                                      scale=0.16,
-                                                      frameColor=TRANSPARENT,
-                                                      command=lambda v: setattr(self, "view_idx", v),
-                                                      extraArgs=[i+3]))
 
         self.__elems = []
         self.__reset()
@@ -765,10 +757,7 @@ class ViewEditor():
             self.__elems[i].frame.set_pos((0.15, 0.0, -0.2 * i))
         self.__elems_frame["canvasSize"] = (-0.95, 0.95, -0.2 * len(self.__elems) + 0.1, 0.1)
 
-        if self.view_idx < 3:
-            self.__selected_view_outline.set_pos((-0.7 + self.view_idx * 0.7, 0.4, -4.4))
-        else:
-            self.__selected_view_outline.set_pos((-0.7 + (self.view_idx - 3) * 0.7, 0.4, -4.9))
+        self.__selected_view_outline.set_pos((-0.7 + (self.view_idx % 3) * 0.7, 0.4, -4.4 - 0.5 * (self.view_idx // 3)))
 
         self.__select_cv(self.__elems[0] if self.__elems else None)
 

--- a/src/simulator/views/gui/view_editor.py
+++ b/src/simulator/views/gui/view_editor.py
@@ -234,6 +234,10 @@ class ColourView():
     def frame(self) -> DirectFrame:
         return self.__frame
 
+    @property
+    def view(self) -> DirectFrame:
+        return self.__view
+        
     def destroy(self) -> None:
         self.__view.destroy()
         self.__frame.destroy()
@@ -285,6 +289,7 @@ class ColourChannel():
                                                     borderWidth=(0.0, 0.0),
                                                     frameSize=(-0.6, 0.9, -0.2, 0.2),
                                                     suppressMouse=True)
+        self.__disable_frame_overlay.hide()
         self.__enabled = True
 
         self.__set_callbacks()
@@ -503,12 +508,12 @@ class ViewElement():
         self.__cv.frame.set_scale((0.15, 1.0, 0.15))
         self.__cv.frame.set_pos((-0.65, 1.0, 0.0))
 
-        self.__cv_btn = DirectButton(parent=self.__frame,
+        self.__cv_btn = DirectButton(parent=self.__cv.frame,
                                      frameColor=TRANSPARENT,
                                      borderWidth=(0, 0),
-                                     frameSize=self.__cv.frame["frameSize"],
-                                     scale=self.__cv.frame["scale"],
-                                     pos=self.__cv.frame["pos"],
+                                     frameSize=self.__cv.view["frameSize"],
+                                     scale=self.__cv.view["scale"],
+                                     pos=self.__cv.view["pos"],
                                      command=self.__cv_clicked)
 
         self.__label = DirectLabel(parent=self.__frame,

--- a/src/simulator/views/map/data/map_data.py
+++ b/src/simulator/views/map/data/map_data.py
@@ -26,7 +26,7 @@ class MapData:
         self.__root = parent.attach_new_node(self.name)
         self.root.set_transparency(TransparencyAttrib.M_alpha)
 
-        self.add_colour(MapData.BG, Colour(0, 0, 0.2, 1), callback=lambda dc: self._services.graphics.window.set_background_color(*dc()))
+        self._add_colour(MapData.BG, Colour(0, 0, 0.2, 1), callback=lambda dc: self._services.graphics.window.set_background_color(*dc()))
     
     def notify(self, event: Event) -> None:
         if isinstance(event, ColourUpdateEvent):
@@ -52,7 +52,7 @@ class MapData:
     def _colour_update_callback(self, colour: DynamicColour) -> None:
         self._services.ev_manager.post(KeyFrameEvent(refresh=True))
 
-    def add_colour(self, name: str, default_colour: Colour, default_visible: bool = True, invoke_callback: bool = True, callback: Optional[Callable[[DynamicColour], None]] = None) -> DynamicColour:
+    def _add_colour(self, name: str, default_colour: Colour, default_visible: bool = True, invoke_callback: bool = True, callback: Optional[Callable[[DynamicColour], None]] = None) -> DynamicColour:
         if callback is None:
             callback = self._colour_update_callback
         if name not in self.__colour_callbacks:

--- a/src/simulator/views/map/data/map_data.py
+++ b/src/simulator/views/map/data/map_data.py
@@ -49,15 +49,12 @@ class MapData:
     def name(self) -> NodePath:
         return self.__name
 
-    def _colour_update_callback(self, colour: DynamicColour) -> None:
-        self._services.ev_manager.post(KeyFrameEvent(refresh=True))
-
     def _add_colour(self, name: str, default_colour: Colour, default_visible: bool = True, invoke_callback: bool = True, callback: Optional[Callable[[DynamicColour], None]] = None) -> DynamicColour:
+        dc = self._services.state.add_colour(name, default_colour, default_visible)
         if callback is None:
-            callback = self._colour_update_callback
+            return
         if name not in self.__colour_callbacks:
             self.__colour_callbacks[name] = callback
-        dc = self._services.state.add_colour(name, default_colour, default_visible)
         if invoke_callback:
             callback(dc)
         return dc

--- a/src/simulator/views/map/data/map_data.py
+++ b/src/simulator/views/map/data/map_data.py
@@ -27,7 +27,7 @@ class MapData:
         self.root.set_transparency(TransparencyAttrib.M_alpha)
 
         self._add_colour(MapData.BG, Colour(0, 0, 0.2, 1), callback=lambda dc: self._services.graphics.window.set_background_color(*dc()))
-    
+
     def notify(self, event: Event) -> None:
         if isinstance(event, ColourUpdateEvent):
             if event.colour.name in self.__colour_callbacks:

--- a/src/simulator/views/map/data/voxel_map.py
+++ b/src/simulator/views/map/data/voxel_map.py
@@ -4,7 +4,7 @@ from simulator.services.services import Services
 from simulator.views.map.data.map_data import MapData
 from simulator.views.map.object.cube_mesh import CubeMesh
 
-from structures import Point, DynamicColour, Colour, TRANSPARENT
+from structures import Point, DynamicColour, Colour, TRANSPARENT, WHITE, BLACK
 
 from typing import List
 import random
@@ -56,10 +56,10 @@ class VoxelMap(MapData):
         self.obstacles_wf.setRenderModeWireframe()
         self.obstacles_wf.setRenderModeThickness(2.2)
 
-        self._add_colour(VoxelMap.TRAVERSABLES, Colour(1), callback=self.__traversables_colour_callback)
-        self._add_colour(VoxelMap.TRAVERSABLES_WF, Colour(0), callback=lambda dc: self.__mesh_colour_callback(dc, self.traversables_wf))
-        self._add_colour(VoxelMap.OBSTACLES, Colour(0), callback=lambda dc: self.__mesh_colour_callback(dc, self.obstacles))
-        self._add_colour(VoxelMap.OBSTACLES_WF, Colour(1), callback=lambda dc: self.__mesh_colour_callback(dc, self.obstacles_wf))
+        self._add_colour(VoxelMap.TRAVERSABLES, WHITE, callback=self.__traversables_colour_callback)
+        self._add_colour(VoxelMap.TRAVERSABLES_WF, BLACK, callback=lambda dc: self.__mesh_colour_callback(dc, self.traversables_wf))
+        self._add_colour(VoxelMap.OBSTACLES, BLACK, callback=lambda dc: self.__mesh_colour_callback(dc, self.obstacles))
+        self._add_colour(VoxelMap.OBSTACLES_WF, WHITE, callback=lambda dc: self.__mesh_colour_callback(dc, self.obstacles_wf))
 
         self._add_colour(VoxelMap.AGENT, Colour(0.8, 0, 0))
         self._add_colour(VoxelMap.TRACE, Colour(0, 0.9, 0))

--- a/src/simulator/views/map/data/voxel_map.py
+++ b/src/simulator/views/map/data/voxel_map.py
@@ -56,14 +56,14 @@ class VoxelMap(MapData):
         self.obstacles_wf.setRenderModeWireframe()
         self.obstacles_wf.setRenderModeThickness(2.2)
 
-        self.add_colour(VoxelMap.TRAVERSABLES, Colour(1), callback=self.__traversables_colour_callback)
-        self.add_colour(VoxelMap.TRAVERSABLES_WF, Colour(0), callback=lambda dc: self.__mesh_colour_callback(dc, self.traversables_wf))
-        self.add_colour(VoxelMap.OBSTACLES, Colour(0), callback=lambda dc: self.__mesh_colour_callback(dc, self.obstacles))
-        self.add_colour(VoxelMap.OBSTACLES_WF, Colour(1), callback=lambda dc: self.__mesh_colour_callback(dc, self.obstacles_wf))
+        self._add_colour(VoxelMap.TRAVERSABLES, Colour(1), callback=self.__traversables_colour_callback)
+        self._add_colour(VoxelMap.TRAVERSABLES_WF, Colour(0), callback=lambda dc: self.__mesh_colour_callback(dc, self.traversables_wf))
+        self._add_colour(VoxelMap.OBSTACLES, Colour(0), callback=lambda dc: self.__mesh_colour_callback(dc, self.obstacles))
+        self._add_colour(VoxelMap.OBSTACLES_WF, Colour(1), callback=lambda dc: self.__mesh_colour_callback(dc, self.obstacles_wf))
 
-        self.add_colour(VoxelMap.AGENT, Colour(0.8, 0, 0))
-        self.add_colour(VoxelMap.TRACE, Colour(0, 0.9, 0))
-        self.add_colour(VoxelMap.GOAL, Colour(0, 0.9, 0))
+        self._add_colour(VoxelMap.AGENT, Colour(0.8, 0, 0))
+        self._add_colour(VoxelMap.TRACE, Colour(0, 0.9, 0))
+        self._add_colour(VoxelMap.GOAL, Colour(0, 0.9, 0))
 
     def __traversables_colour_callback(self, dc: DynamicColour) -> None:
         self.traversables_mesh.default_colour = dc()

--- a/src/simulator/views/map/data/voxel_map.py
+++ b/src/simulator/views/map/data/voxel_map.py
@@ -67,7 +67,7 @@ class VoxelMap(MapData):
 
     def __traversables_colour_callback(self, dc: DynamicColour) -> None:
         self.traversables_mesh.default_colour = dc()
-        self._dynamic_colour_callback(dc)
+        self._colour_update_callback(dc)
 
     def __mesh_colour_callback(self, dc: DynamicColour, np: NodePath) -> None:
         if dc.visible:

--- a/src/simulator/views/map/data/voxel_map.py
+++ b/src/simulator/views/map/data/voxel_map.py
@@ -67,7 +67,6 @@ class VoxelMap(MapData):
 
     def __traversables_colour_callback(self, dc: DynamicColour) -> None:
         self.traversables_mesh.default_colour = dc()
-        self._colour_update_callback(dc)
 
     def __mesh_colour_callback(self, dc: DynamicColour, np: NodePath) -> None:
         if dc.visible:

--- a/src/simulator/views/map/display/entities_map_display.py
+++ b/src/simulator/views/map/display/entities_map_display.py
@@ -9,7 +9,6 @@ from algorithms.configuration.entities.trace import Trace
 from algorithms.configuration.maps.map import Map
 from simulator.services.services import Services
 from simulator.views.map.display.map_display import MapDisplay
-from simulator.views.map.data.map_data import MapData
 from simulator.views.map.data.voxel_map import VoxelMap
 
 from structures import DynamicColour
@@ -24,13 +23,13 @@ class EntitiesMapDisplay(MapDisplay):
     __trace_colour: DynamicColour
     __goal_colour: DynamicColour
 
-    def __init__(self, map_data: MapData, services: Services, z_index=100, custom_map: Map = None) -> None:
+    def __init__(self, services: Services, z_index=100, custom_map: Map = None) -> None:
         super().__init__(services, z_index=z_index, custom_map=custom_map)
         self.animation_step = 0
 
-        self.__agent_colour = map_data.colours[VoxelMap.AGENT]
-        self.__trace_colour = map_data.colours[VoxelMap.TRACE]
-        self.__goal_colour = map_data.colours[VoxelMap.GOAL]
+        self.__agent_colour = self._services.state.effective_view.colours[VoxelMap.AGENT]
+        self.__trace_colour = self._services.state.effective_view.colours[VoxelMap.TRACE]
+        self.__goal_colour = self._services.state.effective_view.colours[VoxelMap.GOAL]
 
     def render(self) -> bool:
         if not super().render():

--- a/src/simulator/views/map/display/graph_map_display.py
+++ b/src/simulator/views/map/display/graph_map_display.py
@@ -12,11 +12,15 @@ if TYPE_CHECKING:
 class GraphMapDisplay(MapDisplay):
     __graph: 'Graph'
 
-    COLOUR: Colour = RED
+    edge_colour: Colour
+    node_colour: Colour
 
     def __init__(self, services: Services, graph: 'Graph', custom_map: Map = None) -> None:
         super().__init__(services, z_index=250, custom_map=custom_map)
         self.__graph = graph
+
+        self.edge_colour = self._services.state.add_colour("graph edge", RED)
+        self.node_colour = self._services.state.add_colour("graph node", RED)
 
     def render(self) -> bool:
         if not super().render():
@@ -34,13 +38,13 @@ class GraphMapDisplay(MapDisplay):
 
     def __render_edge(self, current: 'Vertex'):
         for parent in current.parents:
-            self.get_renderer_view().draw_line(GraphMapDisplay.COLOUR, current.position, parent.position)
+            self.get_renderer_view().draw_line(self.edge_colour(), current.position, parent.position)
 
     def __render_node(self, current: 'Vertex') -> None:
         if self._map.size.n_dim == 2:
-            self.get_renderer_view().draw_circle_filled(current.position, colour=GraphMapDisplay.COLOUR)
+            self.get_renderer_view().draw_circle_filled(current.position, colour=self.node_colour())
         else:
-            self.get_renderer_view().draw_sphere(current.position, colour=GraphMapDisplay.COLOUR)
+            self.get_renderer_view().draw_sphere(current.position, colour=self.node_colour())
 
     def __lt__(self, other):
         return super().__lt__(other)

--- a/src/simulator/views/map/map_view.py
+++ b/src/simulator/views/map/map_view.py
@@ -80,7 +80,7 @@ class MapView(View):
         self.__center(self.__map.root)
 
         # GUI #
-        self.__vs = ViewEditor(self._services, self.map)
+        self.__vs = ViewEditor(self._services)
 
         self.update_view()
 

--- a/src/simulator/views/map/map_view.py
+++ b/src/simulator/views/map/map_view.py
@@ -126,7 +126,7 @@ class MapView(View):
 
     def __get_displays(self) -> None:
         self.__displays = []
-        displays: List[MapDisplay] = [EntitiesMapDisplay(self.__map, self._services)]
+        displays: List[MapDisplay] = [EntitiesMapDisplay(self._services)]
         # drop map displays if not compatible with display format
         displays += list(
             filter(lambda d: self._services.settings.simulator_grid_display or not isinstance(d, NumbersMapDisplay),
@@ -207,7 +207,7 @@ class MapView(View):
         if y not in self.__tc_scratchpad[x]:
             self.__tc_scratchpad[x][y] = {}
         if z not in self.__tc_scratchpad[x][y]:
-            self.__tc_scratchpad[x][y][z] = self.map.colours["traversables"].colour  # use raw colour
+            self.__tc_scratchpad[x][y][z] = self._services.state.effective_view.colours["traversables"].colour  # use raw colour
         dst = self.__tc_scratchpad[x][y][z]
 
         wda = dst.a * (1 - src.a)  # weighted dst alpha

--- a/src/simulator/views/map/map_view.py
+++ b/src/simulator/views/map/map_view.py
@@ -13,6 +13,7 @@ from simulator.services.services import Services
 from simulator.services.event_manager.events.event import Event
 from simulator.services.event_manager.events.key_frame_event import KeyFrameEvent
 from simulator.services.event_manager.events.take_screenshot_event import TakeScreenshotEvent
+from simulator.services.event_manager.events.colour_update_event import ColourUpdateEvent
 
 from simulator.views.map.display.entities_map_display import EntitiesMapDisplay
 from simulator.views.map.display.map_display import MapDisplay
@@ -90,6 +91,10 @@ class MapView(View):
             if event.refresh:
                 self.__tc_reset()
             self.update_view()
+        elif isinstance(event, ColourUpdateEvent):
+            if event.view.is_effective():
+                self.__tc_reset()
+                self.update_view()
         elif isinstance(event, TakeScreenshotEvent):
             self.take_screenshot()
 

--- a/src/structures.py
+++ b/src/structures.py
@@ -323,6 +323,12 @@ class DynamicColour:
         if self.__callback is not None:
             self.__callback(self)
     
+    def set_all(self, colour: Colour, visible: bool) -> None:
+        self.__colour = colour
+        self.__visible = visible
+        if self.__callback is not None:
+            self.__callback(self)
+    
     def __repr__(self) -> str:
         return f"DynamicColour(colour={self.__colour}, visible={self.visible})"
 


### PR DESCRIPTION
- `PersistentState` manages data that has a lifetime longer than the program (dumped to a config file).
- `PersistentState` currently stores colours & views (1-6) that a user can switch between
- Periodic and immediate saving of state
- Graphics refactored to use it - specifically `VoxelMap`/`MapData` and `ViewEditor` rework.
- Added capability for an event to be `_unifiable`. Such that if the event is posted multiple times before being handled (popped off the queue), the existing event currently in the queue will absorb the event to be posted. Particularly useful for `KeyFrameEvent` that is often spam posted dozens of times before it is actually handled. Handling a `KeyFrameEvent` is computationally expensive, which means having a method for discarding redundant posts is key.
- Support for dynamically changing algorithm-specific colours with persistence. Currently tested on A* & RRT.